### PR TITLE
Android: Update deprecated dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
I have updated the old "compile" dependency to the new "implementation".
Warnings during build will be gone now.